### PR TITLE
Adding method to find nested matching nodes

### DIFF
--- a/scrape_test.go
+++ b/scrape_test.go
@@ -1,0 +1,40 @@
+package scrape
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+const testHTML = `
+<html>
+  <body>
+    <div class="bigbird">
+      <div class="container">
+        <div class="bigbird">
+          Hi, I'm Big Bird
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+`
+
+func TestFindAllNestedReturnsNestedMatchingNodes(t *testing.T) {
+	node, _ := html.Parse(strings.NewReader(testHTML))
+	allResults := FindAllNested(node, ByClass("bigbird"))
+
+	if len(allResults) != 2 {
+		t.Error("Expected 2 nodes returned but only found", len(allResults))
+	}
+}
+
+func TestFindAllDoesNotReturnNestedMatchingNodes(t *testing.T) {
+	node, _ := html.Parse(strings.NewReader(testHTML))
+	allResults := FindAll(node, ByClass("bigbird"))
+
+	if len(allResults) != 1 {
+		t.Error("Expected 1 node returned but found", len(allResults))
+	}
+}


### PR DESCRIPTION
This addresses #4 while keeping compatibility with prior behavior. If you'd rather just change the overall behavior, please let me know and I can resubmit. I was worried about people who may be relying on this behavior.

The only usage of it in _this_ library is in TextJoin where it's looking for text nodes (which can't have children; thus the change wouldn't affect this method).

I added a couple of tests to demonstrate both the existing and the new behavior.
