### PR TITLE
New sibling find helper functions

### DIFF
--- a/scrape.go
+++ b/scrape.go
@@ -146,3 +146,44 @@ func findAllInternal(node *html.Node, matcher Matcher, searchNested bool) []*htm
 	}
 	return matched
 }
+
+// Find returns the first node which matches the matcher using next sibling search.
+// If no node is found, ok will be false.
+//
+//     root, err := html.Parse(resp.Body)
+//     if err != nil {
+//         // handle error
+//     }
+//     matcher := func(n *html.Node) bool {
+//         return n.DataAtom == atom.Body
+//     }
+//     body, ok := scrape.FindNextSibling(root, matcher)
+func FindNextSibling(node *html.Node, matcher Matcher) (n *html.Node, ok bool) {
+
+	for s := node.NextSibling; s != nil; s = s.NextSibling {
+		if matcher(s) {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+// Find returns the first node which matches the matcher using previous sibling search.
+// If no node is found, ok will be false.
+//
+//     root, err := html.Parse(resp.Body)
+//     if err != nil {
+//         // handle error
+//     }
+//     matcher := func(n *html.Node) bool {
+//         return n.DataAtom == atom.Body
+//     }
+//     body, ok := scrape.FindPrevSibling(root, matcher)
+func FindPrevSibling(node *html.Node, matcher Matcher) (n *html.Node, ok bool) {
+	for s := node.PrevSibling; s != nil; s = s.PrevSibling {
+		if matcher(s) {
+			return s, true
+		}
+	}
+	return nil, false
+}

--- a/scrape_test.go
+++ b/scrape_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 const testHTML = `
@@ -21,6 +22,25 @@ const testHTML = `
 </html>
 `
 
+const testSiblingHTML = `
+<html>
+   <body>
+   		<div>
+   			<p id="a" class="t1">
+   				aaa
+   				<br/>
+   				<a class="t3">test anchor</a>
+   			</p>
+   			<p id="b" class="t2">bbb
+   				<a class="t1">another anchor</a>
+   			</p>
+   			<p id="c" class="t3">ccc</p>
+   			<p id="d" class="t4">ddd</p>
+   		</div>
+   	</body>
+ </html>
+ `
+
 func TestFindAllNestedReturnsNestedMatchingNodes(t *testing.T) {
 	node, _ := html.Parse(strings.NewReader(testHTML))
 	allResults := FindAllNested(node, ByClass("bigbird"))
@@ -36,5 +56,71 @@ func TestFindAllDoesNotReturnNestedMatchingNodes(t *testing.T) {
 
 	if len(allResults) != 1 {
 		t.Error("Expected 1 node returned but found", len(allResults))
+	}
+}
+
+func TestFindNextSiblingReturnsMatchingNode(t *testing.T) {
+	node, _ := html.Parse(strings.NewReader(testSiblingHTML))
+
+	startingPoint, ok := Find(node, ById("a"))
+	if !ok {
+		t.Error("Expected to find 'a' P node")
+	} else {
+		t3Node, ok := FindNextSibling(startingPoint, ByClass("t3"))
+		if !ok || t3Node == nil {
+			t.Error("Expected to find a node")
+		} else {
+			if t3Node.DataAtom != atom.P || Text(t3Node) != "ccc" {
+				t.Error("Expected to find the third P node")
+
+			}
+		}
+	}
+}
+
+func TestFindNextSiblingDoesntReturnChildren(t *testing.T) {
+	node, _ := html.Parse(strings.NewReader(testSiblingHTML))
+
+	startingPoint, ok := Find(node, ById("b"))
+	if !ok {
+		t.Error("Expected to find 'b' P node")
+	} else {
+		_, ok := FindNextSibling(startingPoint, ByClass("t1"))
+		if ok {
+			t.Error("Didn't expect to find a next sibling node")
+		}
+	}
+}
+
+func TestFindPrevSiblingReturnsMatchingNode(t *testing.T) {
+	node, _ := html.Parse(strings.NewReader(testSiblingHTML))
+
+	startingPoint, ok := Find(node, ById("c"))
+	if !ok {
+		t.Error("Expected to find the 'c' P node")
+	} else {
+		t1Node, ok := FindPrevSibling(startingPoint, ByClass("t1"))
+		if !ok || t1Node == nil {
+			t.Error("Expected to find a node")
+		} else {
+			if t1Node.DataAtom != atom.P || Text(t1Node) != "aaa test anchor" {
+				t.Error("Expected to find the first P node")
+
+			}
+		}
+	}
+}
+
+func TestFindPrevSiblingDoesntReturnChildren(t *testing.T) {
+	node, _ := html.Parse(strings.NewReader(testSiblingHTML))
+
+	startingPoint, ok := Find(node, ById("c"))
+	if !ok {
+		t.Error("Expected to find 'c' P node")
+	} else {
+		_, ok := FindPrevSibling(startingPoint, ByClass("t3"))
+		if ok {
+			t.Error("Didn't expect to find a next sibling node")
+		}
 	}
 }


### PR DESCRIPTION
I've added two new functions, `FindNextSibling(node *html.Node, matcher Matcher) (n *html.Node, ok bool)` and `FindPrevSibling(node *html.Node, matcher Matcher) (n *html.Node, ok bool)` to allow for searching with matchers but without traversing into children.

Tests included
